### PR TITLE
bug: fixed iisue withh image in api status page

### DIFF
--- a/packages/web/src/pages/api-status/api-status.jsx
+++ b/packages/web/src/pages/api-status/api-status.jsx
@@ -12,10 +12,8 @@ const ApiStatus = () => {
             src={GrittyLogo}
             alt="gritty grammar logo"
             className={style.grittyImg}
-            width="113px"
-            style={{ width: '100%', height: 'auto' }} // prevent image Jank
+           // prevent image Jank
           />
-          <span className={style.status}>Status</span>
         </a>
       </div>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25879426/203528420-b8e6c9b3-6c53-4c86-8ab7-45222dadd467.png)

The logo on the api-status page was large due to a bug in the styling. I have removed the erratic styling and the logo now displays as it should 