### PR TITLE
Added route for the client to pull after sending an audio to check on…

### DIFF
--- a/packages/api/controller/responseStatusController.js
+++ b/packages/api/controller/responseStatusController.js
@@ -1,0 +1,42 @@
+const ResponseStatus = require('../database/models/responseStatusSchema');
+const Message = require('../database/models/messageSchema');
+
+
+// This route can be polled to get the status of the response after sending an audio reply via the /sendAudio route.
+async function getResponseStatus(req, res) {
+
+    const statusId = req.params.statusId;
+
+    if (!statusId) {
+        return res.status(401).json({
+            message: 'statusId is required.'
+        })
+    }
+
+    const responseStatus = ResponseStatus.findOne({
+        _id: statusId
+    });
+
+    if (!responseStatus) {
+        return res.status(401).json({
+            message: 'The provided statusId is invalid'
+        });
+    }
+
+    if (responseStatus.status === 'success') {
+        const message = Message.findOne({
+            conversationId: responseStatus.conversationId
+        });
+
+        return res.json({
+            responseStatus, message
+        });
+    } else {
+        return res.json({
+            responseStatus
+        });
+    }
+}
+
+
+module.exports = getResponseStatus;


### PR DESCRIPTION
### Added route for the client to pull from after sending an audio with the `/sendAudio` route to check on response status.

### Route:
`. /api/v1/conversation/responseStatus`