### PR TITLE
fix/FRO2-44-modify footer links to only essentials

### DIFF
--- a/packages/web/src/modules/static/landing-page/Footer.jsx
+++ b/packages/web/src/modules/static/landing-page/Footer.jsx
@@ -12,40 +12,30 @@ const Footer = () => {
               <img src={Logo} alt="footer logo" width={200} />
             </div>
           </div>
-          <div className={styles._ftcol3}>
-            <div className={styles._ftcol3title}>More</div>
-            <div className={styles._ftcol3content}>
-              <Link to="/signup">Sign Up</Link>
-              <Link to="/signin">Sign In</Link>
-              <Link to="/legal">Legal</Link>
-              <Link to="/terms-of-use">Terms of use</Link>
-            </div>
-          </div>
+        
           <div className={styles._ftcol2}>
-            <div className={styles._ftcol2title}>Useful Links</div>
+            <div className={styles._ftcol2title}>Resources</div>
             <div className={styles._ftcol2content}>
               <Link to="/faq">FAQ</Link>
               <Link to="/career">Careers and Culture</Link>
               <Link to="/newsletter">Newsletter</Link>
-              <Link to="/app-status">Api Status</Link>
+              <Link to="/legal">Legal</Link>
+              <Link to="/terms">Terms of Use</Link>
             </div>
           </div>
           <div className={styles._ftcol1}>
-            <div className={styles._ftcol1title}>General</div>
+            <div className={styles._ftcol1title}>Products</div>
             <div className={styles._ftcol1content}>
               <Link to="/home">Home</Link>
               <Link to="/about">About</Link>
               <Link to="/blog">Blog</Link>
               <Link to="/testimonials">Testimonial</Link>
+              <Link to="/api-status">API status</Link>
             </div>
           </div>
           <div className={styles._ftsidebar}></div>
         </div>
-        <div className={styles._ftstarted}>
-          <p>
-            Get Started for Free <Link to="/signup">Sign Up</Link>
-          </p>
-        </div>
+       
         <div className={styles._ftcopyright}>
           <p>&copy;2022 GrittyGrammar</p>
         </div>


### PR DESCRIPTION
# What I did
- Removed 'Get Started' section from footer
- Reduced links to 2 columns 

[Linear](https://linear.app/team-grit/issue/FRO2-44/footer-modifications)

### Before
![grit-footer](https://user-images.githubusercontent.com/72361299/204734611-23302bed-f759-4b14-b08a-98118334491b.png)

### After
![footer-after](https://user-images.githubusercontent.com/72361299/204734721-d06b9a2c-6ba3-4a3f-a7dd-afda6accb7c1.png)
