### PR TITLE
I changed the spelling of a word

### DIFF
--- a/packages/web/src/modules/static/landing-page/NewsLetter.jsx
+++ b/packages/web/src/modules/static/landing-page/NewsLetter.jsx
@@ -59,7 +59,7 @@ const NewsLetter = () => {
     >
       <h5 className="text-xl md:text-3xl font-black -mb-2">Be the first to know</h5>
       <p className="text-center md:text-left">
-        Subscribe to out newsletter and be the first to know about new updates and news, but no spam, scouts honor!
+        Subscribe to our newsletter and be the first to know about new updates and news, but no spam, scouts honor!
       </p>
 
       <form onSubmit={handleSubmit} encType="application/json" className="relative md:w-[80%] flex ">


### PR DESCRIPTION
I forgot to change a spelling error in the newsletter. It has been fixed now 
<img width="1440" alt="Screen Shot 2022-12-13 at 7 13 26 PM" src="https://user-images.githubusercontent.com/80992383/207412643-6d705e33-1ea8-4ae4-8b5f-7c765ce8ac79.png">
